### PR TITLE
Provide Room in the content block callback for RoomScope

### DIFF
--- a/Sources/LiveKitComponents/Scopes/RoomScope.swift
+++ b/Sources/LiveKitComponents/Scopes/RoomScope.swift
@@ -18,7 +18,7 @@ import LiveKit
 import SwiftUI
 
 public struct RoomScope<Content: View>: View {
-    private let _content: () -> Content
+    private let _content: (_: Room) -> Content
     @StateObject private var _room: Room
 
     private let _url: String?
@@ -35,7 +35,7 @@ public struct RoomScope<Content: View>: View {
                 enableCamera: Bool = false,
                 enableMicrophone: Bool = false,
                 roomOptions: RoomOptions? = nil,
-                @ViewBuilder _ content: @escaping () -> Content)
+                @ViewBuilder _ content: @escaping (_: Room) -> Content)
     {
         __room = StateObject(wrappedValue: room ?? Room(roomOptions: roomOptions))
         _url = url
@@ -46,8 +46,22 @@ public struct RoomScope<Content: View>: View {
         _content = content
     }
 
+    public init(room: Room? = nil,
+                url: String? = nil,
+                token: String? = nil,
+                connect: Bool = true,
+                enableCamera: Bool = false,
+                enableMicrophone: Bool = false,
+                roomOptions: RoomOptions? = nil,
+                @ViewBuilder _ content: @escaping () -> Content)
+    {
+        self.init { _ in
+            content()
+        }
+    }
+
     public var body: some View {
-        _content()
+        _content(_room)
             .environmentObject(_room)
             .onAppear {
                 if _connect, let url = _url, let token = _token {


### PR DESCRIPTION
This makes RoomScope more closely match other helpers by providing two ways to get the room - either through `@EnvironmentObject` or through a param.

It simplifies the use of multiple delegates on `Room`, such as with Krisp filtering, by allowing you to add them after room creation without adding extra custom views:

```
  RoomScope(url: ... 
                      token: ...,
                      connect: true,
                      enableCamera: true,
                      enableMicrophone: true) { room in
    room.add(delegate: krispProcessor)
    return VStack {
        ForEachParticipant { _ in
            VStack {
                ForEachTrack(filter: .video) { _ in
                    MyVideoView()
                }
            }
        }
    }
}
```